### PR TITLE
Print full test and solutions

### DIFF
--- a/Create.py
+++ b/Create.py
@@ -1775,16 +1775,16 @@ def main():
     # Ausgabe
     output = OutputManager()
 
-    # Konsolen-Ausgabe (gekürzt)
+    # Konsolen-Ausgabe (vollständig)
     print("\n" + "=" * 50)
-    print("TEST PREVIEW (erste 1000 Zeichen):")
+    print("TEST AUSGABE:")
     print("=" * 50)
-    print(test_content[:1000] + "...")
+    print(test_content)
 
     print("\n" + "=" * 50)
-    print("LÖSUNGEN PREVIEW (erste 1000 Zeichen):")
+    print("LÖSUNGEN AUSGABE:")
     print("=" * 50)
-    print(solutions[:1000] + "...")
+    print(solutions)
 
     # Dateien speichern
     print("\n" + "=" * 50)


### PR DESCRIPTION
## Summary
- show full test and solution content in console output instead of truncating after 1000 characters

## Testing
- `python scripts/hide_ausgangsmaterial.py`
- `pre-commit run --files Create.py`
- `printf '2\n' | python Create.py | nl -ba`

------
https://chatgpt.com/codex/tasks/task_e_68b3e14c4b448327a9f93b372693a85d