### PR TITLE
Fix LaTeX escape warnings in LaTeX output

### DIFF
--- a/Create.py
+++ b/Create.py
@@ -1995,18 +1995,18 @@ Bestehensgrenze: 60 Punkte
             if in_code:
                 continue
             if line.startswith("## "):
-                latex += f"\section{{{_tex_escape(line[3:])}}}\n"
+                latex += r"\section{" + _tex_escape(line[3:]) + "}\n"
             elif line.startswith("### "):
-                latex += f"\subsection{{{_tex_escape(line[4:])}}}\n"
+                latex += r"\subsection{" + _tex_escape(line[4:]) + "}\n"
             elif line.startswith("**") and line.endswith("**"):
                 latex += f"\textbf{{{_tex_escape(line[2:-2])}}}\n\n"
             elif line.startswith("*") and line.endswith("*"):
                 latex += f"\textit{{{_tex_escape(line[1:-1])}}}\n\n"
             elif line.startswith("- "):
                 if not in_list:
-                    latex += "\begin{itemize}\n"
+                    latex += r"\begin{itemize}" + "\n"
                     in_list = True
-                latex += f"\item {_tex_escape(line[2:])}\n"
+                latex += r"\item " + _tex_escape(line[2:]) + "\n"
                 continue
             elif line.startswith("|"):
                 cols = [c.strip() for c in line.strip("|").split("|")]
@@ -2016,7 +2016,7 @@ Bestehensgrenze: 60 Punkte
                     in_table = True
                     expected_cols = len(cols)
                     colspec = " | ".join(["l"] * expected_cols)
-                    latex += f"\begin{{tabular}}{{{colspec}}}\n\hline\n"
+                    latex += r"\begin{tabular}{" + colspec + "}\n" + r"\hline" + "\n"
                 else:
                     if len(cols) < expected_cols:
                         cols += [""] * (expected_cols - len(cols))
@@ -2026,10 +2026,10 @@ Bestehensgrenze: 60 Punkte
                 continue
             else:
                 if in_list:
-                    latex += "\\end{itemize}\n"
+                    latex += r"\end{itemize}" + "\n"
                     in_list = False
                 if in_table:
-                    latex += "\\hline\n\\end{tabular}\n\n"
+                    latex += r"\hline" + "\n" + r"\end{tabular}" + "\n\n"
                     in_table = False
                 if "=" in line and any(
                     op in line for op in ["+", "-", "·", ":", "(", ")"]
@@ -2040,9 +2040,9 @@ Bestehensgrenze: 60 Punkte
                     latex += _tex_escape(line) + "\n\n"
 
         if in_list:
-            latex += "\\end{itemize}\n"
+            latex += r"\end{itemize}" + "\n"
         if in_table:
-            latex += "\\hline\n\\end{tabular}\n"
+            latex += r"\hline" + "\n" + r"\end{tabular}" + "\n"
 
         latex += r"\end{document}"
 


### PR DESCRIPTION
## Summary
- use raw strings when emitting LaTeX commands to avoid invalid escape warnings

## Testing
- `python Create.py --help`
- `autoflake --remove-all-unused-imports --remove-unused-variables -r .`
- `pycln .`
- `unimport .`
- `isort .`
- `black .`
- `docformatter -r .`
- `ruff check --fix .`
- `eradicate -r .`
- `vulture .`
- `radon cc -s .`
- `mdformat AGENTS.md README.md`
- `python -c "import nbformat, sys; print(nbformat.__version__)"`
- `python -c "import importlib.metadata as im; print(im.version('libcst'))"`
- `python -c "import importlib.metadata as im; print(im.version('rope'))"`
- `bowler --version`
- `python -c "import redbaron; import importlib.metadata as im; print(im.version('redbaron'))"`
- `monkeytype list-modules`
- `pyannotate --help`
- `pre-commit run --all-files`
- `pytest`
- `wily build .`


------
https://chatgpt.com/codex/tasks/task_e_68b45905c060832795c610c93ff53e6a