### PR TITLE
docs: add Windows 11 installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,31 @@
 Hier sind die wichtigsten Punkte:
 
+## Installation unter Windows 11
+
+1. [Python 3.12](https://www.python.org/downloads/windows/) installieren und bei der Installation "Add Python to PATH" aktivieren.
+1. PowerShell **als Administrator** öffnen und die Ausführung von Skripten erlauben:
+   ```powershell
+   Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
+   ```
+1. Projektverzeichnis klonen und wechseln:
+   ```powershell
+   git clone <REPO-URL>
+   cd Testmaker
+   ```
+1. Virtuelle Umgebung anlegen und aktivieren:
+   ```powershell
+   python -m venv .venv
+   .\.venv\Scripts\Activate
+   ```
+1. Abhängigkeiten in der virtuellen Umgebung installieren:
+   ```powershell
+   pip install -r requirements.txt
+   ```
+1. Generator starten:
+   ```powershell
+   python Create.py
+   ```
+
 ## Sensible Daten
 
 Der Ordner `Ausgangsmaterial` enthält vertrauliche Dokumente und wird nicht versioniert.

--- a/smoke_check.py
+++ b/smoke_check.py
@@ -132,11 +132,6 @@ def check_complete_generation(seed: int, var_symbol: str = "x"):
 
     # 4) Gleichungen: Variable konsistent
     if var_symbol != "x":
-        eq_lines_task = [
-            ln
-            for ln in test_md.splitlines()
-            if "Gleichungen" in ln or ("=" in ln and ("(" in ln and ")" in ln))
-        ]
         eq_lines_sol = [
             ln
             for ln in sol_md.splitlines()


### PR DESCRIPTION
## Summary
- document Windows 11 setup steps: execution policy, virtualenv, dependency install, and running the generator
- clean up smoke check by removing an unused variable caught by ruff

## Testing
- `autoflake --remove-all-unused-imports --remove-unused-variables -r .`
- `pycln .`
- `unimport .`
- `isort .`
- `black .`
- `docformatter -r .`
- `ruff check --fix .`
- `eradicate -r .`
- `vulture .`
- `radon cc -s .`
- `wily build .`
- `mdformat AGENTS.md README.md`
- `python -c "import nbformat, sys; print(nbformat.__version__)"`
- `python -c "import importlib.metadata as im; print(im.version('libcst'))"`
- `python -c "import importlib.metadata as im; print(im.version('rope'))"`
- `bowler --version`
- `python -c "import redbaron; import importlib.metadata as im; print(im.version('redbaron'))"`
- `monkeytype list-modules`
- `pyannotate --help`
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1178247308327a857cd3086afa546